### PR TITLE
Basic gene annotation display on gene show page

### DIFF
--- a/components/tables/InterproTable.tsx
+++ b/components/tables/InterproTable.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+
+import TextLink from "../atomic/TextLink"
+import SortableTable from "./generics/SortableTable"
+
+const InterproTable = ({ geneAnnotations }) => {
+  const columns = React.useMemo(
+    () => [
+      {
+        Header: "PFAM Identifier",
+        accessor: "label",
+      },
+      {
+        Header: "PFAM name",
+        accessor: "details.desc",
+      },
+      {
+        Header: "GO Terms",
+        accessor: "details.go_terms",
+        Cell: ({value: goTerms}) => {
+          console.log(goTerms)
+          return goTerms.map((goTerm, i) => (
+            <TextLink href="#" key={i}>
+              {goTerm}{"  "}
+            </TextLink>
+          ))
+        },
+      },
+    ], []
+  )
+
+  return (
+    <SortableTable columns={columns} data={geneAnnotations} />
+  )
+}
+
+export default InterproTable

--- a/components/tables/InterproTable.tsx
+++ b/components/tables/InterproTable.tsx
@@ -18,7 +18,6 @@ const InterproTable = ({ geneAnnotations }) => {
         Header: "GO Terms",
         accessor: "details.go_terms",
         Cell: ({value: goTerms}) => {
-          console.log(goTerms)
           return goTerms.map((goTerm, i) => (
             <TextLink href="#" key={i}>
               {goTerm}{"  "}

--- a/components/tables/MapmanTable.tsx
+++ b/components/tables/MapmanTable.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import SortableTable from "./generics/SortableTable"
+
+const MapmanTable = ({ geneAnnotations }) => {
+  const columns = React.useMemo(
+    () => [
+      {
+        Header: "Bin code",
+        accessor: "label",
+      },
+      {
+        Header: "Bin name",
+        accessor: "details.name",
+      },
+      {
+        Header: "Bin description",
+        accessor: "details.desc",
+      },
+    ], []
+  )
+
+  return (
+    <SortableTable columns={columns} data={geneAnnotations} />
+  )
+}
+
+export default MapmanTable

--- a/components/tables/SpeciesTable.tsx
+++ b/components/tables/SpeciesTable.tsx
@@ -66,7 +66,7 @@ const Table = ({ columns, data }) => {
         setGlobalFilter={setGlobalFilter}
       />
       <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
-        <table className="" {...getTableProps()}>
+        <table className="w-full" {...getTableProps()}>
           <thead className="border-b">
             {headerGroups.map((headerGroup) => (
               <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.id}>

--- a/components/tables/generics/SortableTable.tsx
+++ b/components/tables/generics/SortableTable.tsx
@@ -1,0 +1,79 @@
+import React from "react"
+import {
+  useTable,
+  useSortBy,
+} from "react-table"
+
+const SortableTable = ({ columns, data }) => {
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+  } = useTable(
+    {
+      columns,
+      data,
+    },
+    useSortBy,
+  )
+
+  return (
+    <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
+      <table className="w-full" {...getTableProps()}>
+        <thead className="border-b">
+          {headerGroups.map(headerGroup => (
+            <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.id}>
+              {headerGroup.headers.map(column => (
+                // Add the sorting props to control sorting. For this example
+                // we can add them into the header props
+                <th
+                  className="text-gray-900 font-medium text-left min-w-[120px] px-6 py-4"
+                  {...column.getHeaderProps(column.getSortByToggleProps())}
+                  key={column.id}
+                >
+                  {column.render('Header')}
+                  {/* Add a sort direction indicator */}
+                  <span>
+                    {column.isSorted
+                      ? column.isSortedDesc
+                        ? ' 🔽'
+                        : ' 🔼'
+                      : ''}
+                  </span>
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.map(
+            (row, i) => {
+              prepareRow(row);
+              return (
+                <tr
+                  className="bg-white border-b last:border-0"
+                  {...row.getRowProps()} key={row.id}
+                >
+                  {row.cells.map(cell => {
+                    return (
+                      <td
+                        className="text-gray-900 text-sm font-light px-6 py-4"
+                        {...cell.getCellProps()}
+                        key={cell.id}
+                      >
+                        {cell.render('Cell')}
+                      </td>
+                    )
+                  })}
+                </tr>
+              )}
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default SortableTable

--- a/components/tables/generics/SortableTable.tsx
+++ b/components/tables/generics/SortableTable.tsx
@@ -19,6 +19,15 @@ const SortableTable = ({ columns, data }) => {
     useSortBy,
   )
 
+  {
+    /* If rows is empty, don't render any table at all */
+    if (rows.length === 0) return (
+      <p className="">
+        No entries
+      </p>
+    )
+  }
+
   return (
     <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
       <table className="w-full" {...getTableProps()}>

--- a/models/gene.js
+++ b/models/gene.js
@@ -1,5 +1,7 @@
 import { Schema, model, models, ObjectId } from "mongoose";
 
+import GeneAnnotation from "./geneAnnotation";
+
 const geneSchema = new Schema({
   label: {
     type: String,
@@ -18,9 +20,18 @@ const geneSchema = new Schema({
     type: [ObjectId],
     required: true,
     default: [],
+    ref: "GeneAnnotation", // run .populate("ga_ids") to get objects
   },
-
 })
+
+geneSchema.virtual("gene_annotations", {
+  ref: "GeneAnnotation",
+  localField: "ga_ids",
+  foreignField: "_id",
+})
+/* These are needed for virtual fields to appear */
+geneSchema.set("toObject", { virtuals: true })
+geneSchema.set("toJSON", { virtuals: true })
 
 const Gene = models.Gene || model("Gene", geneSchema, "genes")
 

--- a/models/geneAnnotation.js
+++ b/models/geneAnnotation.js
@@ -1,0 +1,26 @@
+import { Schema, model, models, ObjectId } from "mongoose";
+
+
+const geneAnnotationSchema = new Schema(
+  {
+    type: {
+      $type: String,
+      required: true,
+    },
+    label: {
+      $type: String,
+      required: true,
+    },
+    details: {
+      $type: Object,
+    },
+    // TODO: add other fields
+  }, { typeKey: "$type", strict: "throw" }
+)
+/* The schema will use the keyword $type to set the type of the field. And you can safely use type to set the name of the field. */
+
+const GeneAnnotation =
+  models.GeneAnnotation ||
+  model("GeneAnnotation", geneAnnotationSchema, "gene_annotations");
+
+export default GeneAnnotation

--- a/models/geneAnnotationBucket.js
+++ b/models/geneAnnotationBucket.js
@@ -1,0 +1,26 @@
+import { Schema, model, models, ObjectId } from "mongoose";
+
+const geneAnnotationBucketSchema = new Schema(
+  {
+    ga_id: {
+      $type: ObjectId,
+      required: true,
+    },
+    tax: {
+      $type: Number,
+      required: true,
+    },
+    gene_ids: {
+      $type: Array[ObjectId],
+      required: true,
+    },
+  },
+  { strict: "throw" }
+);
+/* The schema will use the keyword $type to set the type of the field. And you can safely use type to set the name of the field. */
+
+const GeneAnnotationBucket =
+  models.GeneAnnotationBucket ||
+  model("GeneAnnotationBucket", geneAnnotationBucketSchema, "gene_annotation_buckets");
+
+export default GeneAnnotationBucket;

--- a/pages/species/[taxid]/genes/[geneLabel].tsx
+++ b/pages/species/[taxid]/genes/[geneLabel].tsx
@@ -10,6 +10,10 @@ import { getSampleAnnotations } from "../../../../utils/sampleAnnotations"
 import { getOneSpecies } from "../../../../utils/species"
 // import ExpressionPlot from "../../../../components/graphs/expression"
 import * as poNameMap from '/public/data/po_name_map.json' assert {type: 'json'}
+import { getOneGene } from "../../../../utils/genes"
+import MapmanTable from "../../../../components/tables/MapmanTable"
+import InterproTable from "../../../../components/tables/InterproTable"
+import TextLink from "../../../../components/atomic/TextLink"
 
 const ExpressionPlot = dynamic(
   () => import("../../../../components/graphs/expression"),
@@ -19,20 +23,31 @@ const ExpressionPlot = dynamic(
 export const getServerSideProps: GetServerSideProps = async ({ params, query }) => {
   connectMongo()
   const sampleAnnotations = await getSampleAnnotations(params.taxid, params.geneLabel)
-  const highestSpm = sampleAnnotations.reduce(
-    (prev, curr) => prev.spm > curr.spm ? prev : curr
-  )
-  highestSpm.labelName = poNameMap[highestSpm.label]
+  let highestSpm = null
+  if (sampleAnnotations.length > 0) {
+    highestSpm = sampleAnnotations.reduce(
+      (prev, curr) => prev.spm > curr.spm ? prev : curr
+    )
+    highestSpm.labelName = poNameMap[highestSpm.label]
+  }
+
   const species = await getOneSpecies(params.taxid)
+  const gene = await getOneGene(species._id, params.geneLabel)
+  const mapmanGas = gene.gene_annotations.filter(ga => ga.type === "MAPMAN")
+  const interproGas = gene.gene_annotations.filter(ga => ga.type === "INTERPRO")
+
   return {
     props: {
       species: JSON.parse(JSON.stringify(species)),
+      gene: JSON.parse(JSON.stringify(gene)),
+      mapmanGas: JSON.parse(JSON.stringify(mapmanGas)),
+      interproGas: JSON.parse(JSON.stringify(interproGas)),
       highestSpm: JSON.parse(JSON.stringify(highestSpm)),
     }
   }
 }
 
-const GenePage: NextPage = ({species, highestSpm}) => {
+const GenePage: NextPage = ({species, gene, highestSpm, mapmanGas, interproGas}) => {
   const router = useRouter()
   const { taxid, geneLabel } = router.query
 
@@ -53,29 +68,59 @@ const GenePage: NextPage = ({species, highestSpm}) => {
         <h1 className="text-4xl py-4">Gene {geneLabel}</h1>
         <p>Species name: <span className="italic">{species.name}</span></p>
         <p>Taxanomic ID: {taxid}</p>
-        <p>Organ with highest SPM: {highestSpm.labelName} ({highestSpm.label})</p>
-        <p>Highest SPM value: {highestSpm.spm}</p>
+        {highestSpm && (
+          <React.Fragment>
+            <p>Organ with highest SPM: {highestSpm.labelName} ({highestSpm.label})</p>
+            <p>Highest SPM value: {highestSpm.spm}</p>
+          </React.Fragment>
+        )}
+
+        {/* For debugging purposes */}
+        {/* {JSON.stringify(mapmanGas)}
+        {JSON.stringify(interproGas)} */}
+
+        <div className="flex italic text-sm gap-2 my-3">
+          <TextLink href="#mapman-annotations">
+            Mapman annotations
+          </TextLink>
+          <TextLink href="#interpro-annotations">
+            PFAM annotations
+          </TextLink>
+          <TextLink href="#coexpression-table">
+            Coexpressed genes
+          </TextLink>
+        </div>
+
       </section>
 
-      <section className="my-4">
+      <section className="my-4" id="expression-graph">
         <h3 className="text-2xl py-3">Gene expression profile by organs</h3>
+        {!highestSpm && (
+          <p>No annotated samples yet 😢</p>
+        )}
         {loader}
+        {/* TODO:
+          Hide expression plot if no samples
+          Prevent auto rehydrating of graph data
+        */}
         <ExpressionPlot taxid={taxid} geneLabel={geneLabel} hideLoader={hideLoader} />
       </section>
 
-      <section className="my-4">
+      <section className="my-4" id="mapman-annotations">
         <h3 className="text-2xl py-3">Mapman annotations</h3>
-        {/* TODO: make a react table */}
+        <MapmanTable geneAnnotations={mapmanGas} />
       </section>
 
-      <section className="my-4">
+      <section className="my-4" id="interpro-annotations">
         <h3 className="text-2xl py-3">PFAM annotations</h3>
-
+        <InterproTable geneAnnotations={interproGas} />
       </section>
 
-      <section className="my-4">
+      <section className="my-4" id="coexpression-table">
         <h3 className="text-2xl py-3">Top co-expressed genes</h3>
-
+        <p>
+          🚧👷🏻 Coming soon ...
+        </p>
       </section>
     </Layout>
   )

--- a/utils/genes.ts
+++ b/utils/genes.ts
@@ -1,7 +1,12 @@
+import { ObjectId } from "mongoose"
+
 import Species from "../models/species"
 import Gene from "../models/gene"
 import connectMongo from "../utils/connectMongo"
 
+/*
+  Used for species show page, where the table of all genes for the species is at
+ */
 export const getGenesPage = async (
   taxid: number,
   pageIndex: number,
@@ -27,6 +32,24 @@ export const getGenesPage = async (
   }
 }
 
+/*
+  To return a single gene doc with its associated docs
+  For gene show page
+ */
+export const getOneGene = async (
+  species_id: ObjectId,
+  label: string,
+) => {
+  connectMongo()
+  const gene = await Gene.findOne({"spe_id": species_id, "label": label})
+    .populate("gene_annotations")
+  return gene
+}
+
+/*
+  Returns a page of full gene docs
+  Used for search results
+ */
 export const getGenesSearchPage = async (
   searchTerm: string,
   pageIndex: number = 0,
@@ -61,6 +84,11 @@ export const getGenesSearchPage = async (
   }
 }
 
+
+/*
+  Returns just gene labels
+  Used for search recommendations
+ */
 export const getGeneLabelsSearchPage = async (
   searchTerm: string,
   pageIndex: number = 0,


### PR DESCRIPTION
## What has been done

1. API endpoints to get gene docs with its associated gene annotations by reference from DB

2. Abstracted simple sortable table UI into a component. Two derivative component - one for mapman table, one for interpro table, holding the column and row definitions, both then rendered on the gene show page

3. UI Fix: Table content to occupy full width

4. If no gene annotation for the table, don't show the table at all

5. Simple ref links to each section, just basic links, no fancy tabs/buttons yet. Not sure what style we want.

## What has not been done

1. GO Term links are not linked to anything yet
2. Might need to not include `& original description: *` and after in the bin description of the gene annotation