### PR TITLE
fix: update gene annotation doc keys to match new db schema

### DIFF
--- a/components/tables/InterproTable.tsx
+++ b/components/tables/InterproTable.tsx
@@ -12,7 +12,7 @@ const InterproTable = ({ geneAnnotations }) => {
       },
       {
         Header: "PFAM name",
-        accessor: "details.desc",
+        accessor: "name",
       },
       {
         Header: "GO Terms",

--- a/components/tables/MapmanTable.tsx
+++ b/components/tables/MapmanTable.tsx
@@ -10,7 +10,7 @@ const MapmanTable = ({ geneAnnotations }) => {
       },
       {
         Header: "Bin name",
-        accessor: "details.name",
+        accessor: "name",
       },
       {
         Header: "Bin description",


### PR DESCRIPTION
## What has been done

1. Update keys accessed in Gene Annotation object to get name

To align with newer DB schema with compulsory common field name (on top of key label), regardless of annotation type (mapman or interpro).

<img width="474" alt="image" src="https://user-images.githubusercontent.com/59186927/194686522-a7274cf3-32d0-408c-ada4-92b835f68d38.png">
