### PR TITLE
Show gene names (by gene annotation in tables)

### DIFF
--- a/components/atomic/texts/Header1.tsx
+++ b/components/atomic/texts/Header1.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import Link from "next/link"
+
+interface IProps {
+  children: React.ReactNode
+  className?: string
+  href?: string
+}
+
+const Header1: React.FC<IProps> = ({ children, className, href }) => {
+  if (href) {
+    return (
+      <Link href={href}>
+        <a className="hover:underline active:text-plb-red">
+          <h1 className={`text-4xl py-3 ${className}`}>
+            {children}
+          </h1>
+        </a>
+      </Link>
+    )
+  }
+  return (
+    <h1 className={`text-4xl py-3 ${className}`}>
+      {children}
+    </h1>
+  )
+}
+
+export default Header1

--- a/components/atomic/texts/Header2.tsx
+++ b/components/atomic/texts/Header2.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import Link from "next/link"
+
+interface IProps {
+  children: React.ReactNode
+  className?: string
+  href?: string
+}
+
+const Header2: React.FC<IProps> = ({ children, className, href }) => {
+  if (href) {
+    return (
+      <Link href={href}>
+        <a className="hover:underline active:text-plb-red">
+          <h1 className={`text-2xl py-3 ${className}`}>
+            {children}
+          </h1>
+        </a>
+      </Link>
+    )
+  }
+  return (
+    <h1 className={`text-2xl py-3 ${className}`}>
+      {children}
+    </h1>
+  )
+}
+
+export default Header2

--- a/components/search/ProteinSearchBox.tsx
+++ b/components/search/ProteinSearchBox.tsx
@@ -19,7 +19,8 @@ const ProteinSearchBox = ({submitSearchQuery}) => {
 
   const sampleSeq = "MEEENQKSHRVSRKDQSGSHWSQGADEEPRARCSGKRCRSWAAAAIADCVALCCCPCAVVNIFTLAFVKVPWMIGRKCIGRGGPSKKRMKKINREDRFHHHHHHRRSAEMVSGGCCGGGDGDGEFDDHRFVVERDGSLTKEEAKTASLKEEEETRISARVEAERVWLELYQIGHLGFGRVSFTGIHQ"
 
-  const loadExampleSeq = () => {
+  const loadExampleSeq = (event) => {
+    event.preventDefault()
     const textarea: HTMLTextAreaElement = document.querySelector("textarea#proteinSeq")!
     textarea.value = sampleSeq
     textarea.focus()

--- a/components/tables/GenesTable.tsx
+++ b/components/tables/GenesTable.tsx
@@ -25,13 +25,24 @@ const GenesTable: React.FC<IProps> = ({ taxid }) => {
         </TextLink>
       ),
     },
+    // {
+    //   Header: "Alias",
+    //   accessor: "alias",
+    // },
     {
-      Header: "Alias",
-      accessor: "alias",
-    },
-    {
-      Header: "Annotations",
-      accessor: "ga_ids",
+      Header: "Mapman annotations",
+      accessor: "gene_annotations",
+      Cell: ({ value: geneAnnotations }: { value: string }) => (
+        <ul className="space-y-1 max-w-md list-disc list-outside">
+          {
+            geneAnnotations.filter(ga => ga.type == "MAPMAN").map(ga => (
+              <li className="mb-1" key={ga.label}>
+                {ga.name}
+              </li>
+            ))
+          }
+        </ul>
+      )
     },
   ], [taxid])
 

--- a/components/tables/ProteinResultTable.tsx
+++ b/components/tables/ProteinResultTable.tsx
@@ -13,6 +13,9 @@ const ProteinResultTable = ({ columns, data }) => {
     {
       columns,
       data,
+      initialState: {
+        hiddenColumns: ["taxid"]
+      }
     },
     useSortBy,
   )

--- a/components/tables/generics/LocalPaginatedTable.tsx
+++ b/components/tables/generics/LocalPaginatedTable.tsx
@@ -71,6 +71,19 @@ const LoaclPaginatedTable: React.FC<IProps> = ({
           )}
         </code>
       </pre>
+      <PaginationBar
+        {...{
+          pageIndex,  // This is a state from useTable hook
+          pageSize,  // This is a state from useTable hook
+          pageCount,
+          canPreviousPage,
+          previousPage,
+          canNextPage,
+          nextPage,
+          gotoPage,
+          setPageSize,
+        }}
+      />
       <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
         <table className="w-full" {...getTableProps()}>
           <thead className="border-b">
@@ -124,19 +137,6 @@ const LoaclPaginatedTable: React.FC<IProps> = ({
           </tbody>
         </table>
       </div>
-      <PaginationBar
-        {...{
-          pageIndex,  // This is a state from useTable hook
-          pageSize,  // This is a state from useTable hook
-          pageCount,
-          canPreviousPage,
-          previousPage,
-          canNextPage,
-          nextPage,
-          gotoPage,
-          setPageSize,
-        }}
-      />
     </div>
   )
 }

--- a/components/tables/generics/LocalPaginatedTable.tsx
+++ b/components/tables/generics/LocalPaginatedTable.tsx
@@ -1,0 +1,144 @@
+import React from "react"
+import { useTable, usePagination, useSortBy } from 'react-table'
+
+import PaginationBar from "./PaginationBar"
+
+interface IProps {
+  columns: object[]
+  data: object[]
+  pageCount: number
+  loading: boolean
+  fetchData: ({pageIndex, pageSize}: {pageIndex: number, pageSize: number}) => void
+}
+
+const LoaclPaginatedTable: React.FC<IProps> = ({
+  columns,
+  data,
+  pageCount: controlledPageCount,
+  loading,
+  fetchData,
+}) => {
+  const defaultPageSize: number = process.env.pageSize ? parseInt(process.env.pageSize) : 10
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    prepareRow,
+    page,  // Instead of rows
+    canPreviousPage,
+    canNextPage,
+    // pageOptions,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    setPageSize,
+    // setHiddenColumns,
+    state: { pageIndex, pageSize },
+  } = useTable(
+    {
+      columns,
+      data,
+      initialState: { pageIndex: 0, pageSize: defaultPageSize },
+    },
+    useSortBy,
+    usePagination,
+  )
+
+  /*
+    Whenever pageIndex changes, the data will be fetched.
+    useEffect to avoid re-rendering
+  */
+  React.useEffect(() => {
+    fetchData({ pageIndex, pageSize })
+  }, [fetchData, pageIndex, pageSize])
+
+  return (
+    <div>
+      <pre hidden>
+        <code>
+          {JSON.stringify(
+            {
+              pageIndex,
+              pageSize,
+              pageCount,
+              canNextPage,
+              canPreviousPage,
+            },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+      <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
+        <table className="w-full" {...getTableProps()}>
+          <thead className="border-b">
+            {headerGroups.map(headerGroup => (
+              <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.getHeaderGroupProps().key}>
+                {headerGroup.headers.map(column => (
+                  // Add the sorting props to control sorting. For this example
+                  // we can add them into the header props
+                  <th
+                    className="text-gray-900 font-medium text-left min-w-[120px] px-6 py-4"
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    key={column.getHeaderProps().key}
+                  >
+                    {column.render('Header')}
+                    {/* Add a sort direction indicator */}
+                    <span>
+                      {column.isSorted
+                        ? column.isSortedDesc
+                          ? ' 🔽'
+                          : ' 🔼'
+                        : ''}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {page.map((row) => {
+                prepareRow(row);
+                return (
+                  <tr
+                    className="bg-white border-b last:border-0"
+                    {...row.getRowProps()}
+                    key={row.getRowProps().key}
+                  >
+                    {row.cells.map(cell => {
+                      return (
+                        <td
+                          className="text-gray-900 text-sm font-light px-6 py-4"
+                          {...cell.getCellProps()}
+                          key={cell.getCellProps().key}
+                        >
+                          {cell.render('Cell')}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )}
+            )}
+          </tbody>
+        </table>
+      </div>
+      <PaginationBar
+        {...{
+          pageIndex,  // This is a state from useTable hook
+          pageSize,  // This is a state from useTable hook
+          pageCount,
+          canPreviousPage,
+          previousPage,
+          canNextPage,
+          nextPage,
+          gotoPage,
+          setPageSize,
+        }}
+      />
+    </div>
+  )
+}
+
+export default LoaclPaginatedTable

--- a/components/tables/generics/PaginationBar.tsx
+++ b/components/tables/generics/PaginationBar.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+
+const PaginationBar: ReactFC = ({
+  pageIndex,  // This is a state from useTable hook
+  pageSize,  // This is a state from useTable hook
+  pageCount,
+  canPreviousPage,
+  previousPage,
+  canNextPage,
+  nextPage,
+  gotoPage,
+  setPageSize,
+}) => {
+  return (
+    <nav className="flex justify-center">
+      <div className="inline-flex drop-shadow-md my-4">
+        <button
+          className="py-2 px-3 text-gray-500 bg-white rounded-l-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+          onClick={() => gotoPage(0)}
+          disabled={!canPreviousPage}
+        >
+          First
+        </button>
+        <button
+          className="py-2 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+          onClick={() => previousPage()}
+          disabled={!canPreviousPage}
+        >
+          {'<'}
+        </button>
+        <div
+          className="py-2 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        >
+          Go to{" "}
+          <input
+            className="text-center border border-stone-300"
+            type="number"
+            defaultValue={pageIndex + 1}
+            onChange={e => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0
+              gotoPage(page)
+            }}
+            style={{ width: '50px' }}
+          />
+        </div>
+        <div
+          className="py-2 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        >
+          <select
+            className="border border-stone-300"
+            value={pageSize}
+            onChange={e => {
+              setPageSize(Number(e.target.value))
+            }}
+          >
+            {[10, 15, 20, 25, 30].map(pageSize => (
+              <option key={pageSize} value={pageSize}>
+                Show {pageSize}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          className="py-2 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+          onClick={() => nextPage()}
+          disabled={!canNextPage}
+        >
+          {'>'}
+        </button>
+        <button
+          className="py-2 px-5 text-gray-500 bg-white rounded-r-lg border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+          onClick={() => gotoPage(pageCount - 1)}
+          disabled={!canNextPage}
+        >
+          Last
+        </button>
+      </div>
+    </nav>
+  )
+}
+
+export default PaginationBar

--- a/components/tables/generics/VirtualPaginatedTable.tsx
+++ b/components/tables/generics/VirtualPaginatedTable.tsx
@@ -1,0 +1,149 @@
+import React from "react"
+import { useTable, usePagination, useSortBy } from 'react-table'
+
+import PaginationBar from "./PaginationBar"
+
+interface IProps {
+  columns: object[]
+  data: object[]
+  pageCount: number
+  loading: boolean
+  fetchData: ({pageIndex, pageSize}: {pageIndex: number, pageSize: number}) => void
+}
+
+const VirtualPaginatedTable: React.FC<IProps> = ({
+  columns,
+  data,
+  pageCount: controlledPageCount,
+  loading,
+  fetchData,
+}) => {
+  const defaultPageSize: number = process.env.pageSize ? parseInt(process.env.pageSize) : 10
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    prepareRow,
+    page,  // Instead of rows
+    canPreviousPage,
+    canNextPage,
+    // pageOptions,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    setPageSize,
+    // setHiddenColumns,
+    state: { pageIndex, pageSize },
+  } = useTable(
+    {
+      columns,
+      data,
+      initialState: { pageIndex: 0, pageSize: defaultPageSize },
+      manualPagination: true,
+      pageCount: controlledPageCount,  // Needed when doing manualPagination
+      // Needed when useSortBy + usePagination combo of hooks are used
+      // Otherwise, the table just kept resetting to its original state even on page change
+      autoResetPage: false,
+    },
+    useSortBy,
+    usePagination,
+  )
+
+  /*
+    Whenever pageIndex changes, the data will be fetched.
+    useEffect to avoid re-rendering
+  */
+  React.useEffect(() => {
+    fetchData({ pageIndex, pageSize })
+  }, [fetchData, pageIndex, pageSize])
+
+  return (
+    <div>
+      <pre hidden>
+        <code>
+          {JSON.stringify(
+            {
+              pageIndex,
+              pageSize,
+              pageCount,
+              canNextPage,
+              canPreviousPage,
+            },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+      <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
+        <table className="w-full" {...getTableProps()}>
+          <thead className="border-b">
+            {headerGroups.map(headerGroup => (
+              <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.getHeaderGroupProps().key}>
+                {headerGroup.headers.map(column => (
+                  // Add the sorting props to control sorting. For this example
+                  // we can add them into the header props
+                  <th
+                    className="text-gray-900 font-medium text-left min-w-[120px] px-6 py-4"
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    key={column.getHeaderProps().key}
+                  >
+                    {column.render('Header')}
+                    {/* Add a sort direction indicator */}
+                    <span>
+                      {column.isSorted
+                        ? column.isSortedDesc
+                          ? ' 🔽'
+                          : ' 🔼'
+                        : ''}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {page.map((row) => {
+                prepareRow(row);
+                return (
+                  <tr
+                    className="bg-white border-b last:border-0"
+                    {...row.getRowProps()}
+                    key={row.getRowProps().key}
+                  >
+                    {row.cells.map(cell => {
+                      return (
+                        <td
+                          className="text-gray-900 text-sm font-light px-6 py-4"
+                          {...cell.getCellProps()}
+                          key={cell.getCellProps().key}
+                        >
+                          {cell.render('Cell')}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )}
+            )}
+          </tbody>
+        </table>
+      </div>
+      <PaginationBar
+        {...{
+          pageIndex,  // This is a state from useTable hook
+          pageSize,  // This is a state from useTable hook
+          pageCount,
+          canPreviousPage,
+          previousPage,
+          canNextPage,
+          nextPage,
+          gotoPage,
+          setPageSize,
+        }}
+      />
+    </div>
+  )
+}
+
+export default VirtualPaginatedTable

--- a/components/tables/generics/VirtualPaginatedTable.tsx
+++ b/components/tables/generics/VirtualPaginatedTable.tsx
@@ -76,6 +76,19 @@ const VirtualPaginatedTable: React.FC<IProps> = ({
           )}
         </code>
       </pre>
+      <PaginationBar
+        {...{
+          pageIndex,  // This is a state from useTable hook
+          pageSize,  // This is a state from useTable hook
+          pageCount,
+          canPreviousPage,
+          previousPage,
+          canNextPage,
+          nextPage,
+          gotoPage,
+          setPageSize,
+        }}
+      />
       <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
         <table className="w-full" {...getTableProps()}>
           <thead className="border-b">
@@ -129,19 +142,6 @@ const VirtualPaginatedTable: React.FC<IProps> = ({
           </tbody>
         </table>
       </div>
-      <PaginationBar
-        {...{
-          pageIndex,  // This is a state from useTable hook
-          pageSize,  // This is a state from useTable hook
-          pageCount,
-          canPreviousPage,
-          previousPage,
-          canNextPage,
-          nextPage,
-          gotoPage,
-          setPageSize,
-        }}
-      />
     </div>
   )
 }

--- a/pages/api/names/speciesAndGenes.ts
+++ b/pages/api/names/speciesAndGenes.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { getManyGenes } from '../../../utils/genes'
+import { getManySpecies } from '../../../utils/species'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  switch (req.method) {
+    case "POST":
+      try {
+        // The raw array of {taxid, gene_label} objects
+        // derived from diamond search API
+        const hits = req.body
+        // Call Next.js's API to get species name and _id
+        const species = await getManySpecies(hits.map(hit => hit.taxid))
+        // TOFIX: What happens when there is a data mismatch
+        // between the diamond search db and our Mongo DB data?
+        hits.forEach((hit, i) => {
+          if (species[i].tax === hit.taxid) {
+            hit.species_name = species[i].name
+            hit.species_id = species[i]._id
+          }
+        })
+        // Call Next.js's API to get gene's gene annotations
+        // to retrieve MAPMAN annotations (if any)
+        const genes = await getManyGenes(hits)
+        hits.forEach((hit, i) => {
+          if (genes[i].label === hit.gene_label) {
+            // Find all MAPMAN annotations if any,
+            // and add to the doc
+            const mapman_gas = genes[i].gene_annotations.filter(ga => ga.type === "MAPMAN")
+            hit.names = mapman_gas.map(ga => ga.name)
+          }
+        })
+        res.status(200).json(hits)
+      } catch (error) {
+        console.log(error)
+        res.status(422).json({ error: "invalid query" })
+      }
+      break
+    default:
+      console.log("Method not available for this endpoint")
+      res.status(405).json({error: "Method not available for this endpoint"})
+  }
+}

--- a/pages/species/[taxid]/index.tsx
+++ b/pages/species/[taxid]/index.tsx
@@ -1,15 +1,14 @@
 import React from "react";
-import Head from "next/head";
-import Link from "next/link";
-import { NextPage } from "next";
-import { useRouter } from "next/router";
+import Head from "next/head"
+import { NextPage } from "next"
+import { useRouter } from "next/router"
 
-import Layout from "../../../components/Layout";
-import GenesTable from "../../../components/tables/GenesTable";
-import Species from "../../../models/species";
-import { getGenesPage } from "../../../utils/genes";
-import connectMongo from "../../../utils/connectMongo";
-import Header1 from "../../../components/atomic/texts/Header1";
+import Layout from "../../../components/layout"
+import GenesTable from "../../../components/tables/GenesTable"
+import Header1 from "../../../components/atomic/texts/Header1"
+import connectMongo from "../../../utils/connectMongo"
+import Species from "../../../models/species"
+import { getGenesPage } from "../../../utils/genes"
 
 export const getServerSideProps: GetServerSideProps = async ({ params, query }) => {
   connectMongo()
@@ -19,61 +18,21 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
   return {
     props: {
       species: JSON.parse(JSON.stringify(this_species)),
-      initialGenes: JSON.parse(JSON.stringify(genePage.genes)),
-      numGenes: parseInt(genePage.numGenes),
+      // initialGenes: JSON.parse(JSON.stringify(genePage.genes)),
+      // pageTotal: genePage.pageTotal,
+      numGenes: genePage.numGenes,
     },
   }
 }
 
-const SpeciesPage: NextPage = ({ species, initialGenes, numGenes }) => {
+interface IProps {
+  species: Species
+  numGenes: number
+}
+
+const SpeciesPage: NextPage<IProps> = ({ species, numGenes }) => {
   const router = useRouter()
-  const { taxid } = router.query
-
-  // Pagination state management
-  const [ pageCount, setPageCount ] = React.useState(0)
-  const [ loading, setLoading ] = React.useState(false)
-  // Table body data
-  const [ genes, setGenes ] = React.useState(initialGenes)
-  const fetchIdRef = React.useRef(0)
-
-  // Table columns
-  const columns = React.useMemo(() => [
-    {
-      Header: "Gene ID",
-      accessor: "label",
-      Cell: ({ value }) => (
-        <Link href={`/species/${taxid}/genes/${value}`}>
-          <a className="text-plb-green hover:underline active:text-plb-red">{value}</a>
-        </Link>
-      ),
-    },
-    {
-      Header: "Alias",
-      accessor: "alias",
-    },
-    {
-      Header: "Annotations",
-      accessor: "ga_ids",
-    },
-  ], [])
-
-  const fetchGenes = React.useCallback(({ pageSize, pageIndex }: { pageSize: number, pageIndex: number }) => {
-    // This will get called when the table needs new data
-    // Give this fetch an ID
-    const fetchId = ++fetchIdRef.current
-    setLoading(true)
-    // Only update the data if this is the latest fetch
-    if (fetchId === fetchIdRef.current) {
-      fetch(`/api/species/${taxid}/genes?pageIndex=${pageIndex}&pageSize=${pageSize}`)
-        .then(res => res.json())
-        .then((data) => {
-          setGenes(data.genes)
-          setPageCount(data.pageTotal)
-          setLoading(false)
-        })
-        .catch(err => console.log(err))
-    }
-  }, [taxid, setGenes, setPageCount, setLoading])
+  const taxid = parseInt(router.query.taxid!)
 
   return (
     <Layout>
@@ -91,7 +50,7 @@ const SpeciesPage: NextPage = ({ species, initialGenes, numGenes }) => {
       </section>
 
       <section>
-        <GenesTable columns={columns} data={genes} fetchGenes={fetchGenes} loading={loading} pageCount={pageCount} />
+        <GenesTable taxid={taxid} />
       </section>
     </Layout>
   )

--- a/pages/species/[taxid]/index.tsx
+++ b/pages/species/[taxid]/index.tsx
@@ -9,6 +9,7 @@ import GenesTable from "../../../components/tables/GenesTable";
 import Species from "../../../models/species";
 import { getGenesPage } from "../../../utils/genes";
 import connectMongo from "../../../utils/connectMongo";
+import Header1 from "../../../components/atomic/texts/Header1";
 
 export const getServerSideProps: GetServerSideProps = async ({ params, query }) => {
   connectMongo()
@@ -81,7 +82,9 @@ const SpeciesPage: NextPage = ({ species, initialGenes, numGenes }) => {
       </Head>
 
       <section>
-        <h1 className="text-4xl italic py-3">{species.name}</h1>
+        <Header1 className="italic">
+          {species.name}
+        </Header1>
         <p>Taxanomic ID: {taxid}</p>
         <p>Alias: {species.alias.length ? species.alias.join(", ") : "-"}</p>
         <p>Number of genes: {numGenes}</p>

--- a/utils/genes.ts
+++ b/utils/genes.ts
@@ -18,6 +18,9 @@ export const getGenesPage = async (
   const genes = await Gene.find({"spe_id": species_id})
     .skip(pageIndex * pageSize)
     .limit(pageSize)
+    .populate("gene_annotations")
+    .lean()
+
   const numGenes = await Gene.countDocuments({"spe_id": species_id})
   /*
     NOTE: pageTotal is the number of pages required for the given pageSize,

--- a/utils/genes.ts
+++ b/utils/genes.ts
@@ -103,3 +103,23 @@ export const getGeneLabelsSearchPage = async (
     .limit(pageSize)
   return { genes }
 }
+
+
+/*
+  For protein seq search results
+  From an array of taxid and gene label,
+  return gene annotation names (filter for MAPMAN within the API call itself)
+*/
+export const getManyGenes = async (
+  hits: {species_id: ObjectId, gene_label: string}[]
+) => {
+  connectMongo()
+  const results = Promise.all(
+    hits.map(async (hit) => {
+      return await Gene.findOne({ spe_id: hit.species_id, label: hit.gene_label })
+        .populate("gene_annotations")
+        .lean()
+    })
+  )
+  return results
+}

--- a/utils/species.ts
+++ b/utils/species.ts
@@ -6,3 +6,20 @@ export const getOneSpecies = async (taxid: number) => {
   const species = await Species.findOne({"tax": taxid}).lean()
   return species
 }
+
+/*
+  For protein seq search results
+  From an array of taxid,
+  return species name
+*/
+export const getManySpecies = async (
+  taxids: number[]
+) => {
+  connectMongo()
+  const results = Promise.all(
+    taxids.map(async (taxid) => {
+      return await Species.findOne({ tax: taxid }, "_id tax name").lean()
+    })
+  )
+  return results
+}


### PR DESCRIPTION
## What has been done?

1. Species show page has a list of paginated genes table, with all its gene annotation name shown.

    - Ugly bullet points. Remove?
    - The table width seems problematic for gene annotations

<img width="1544" alt="image" src="https://user-images.githubusercontent.com/59186927/195114760-a1500328-3faa-46a7-88c5-709a166d67fa.png">

2. Protein seqeuence search results have species name and MAPMAN annotation names.

    - Usually same MAPMAN names because we derive the MAPMAN names using diamond too ...

<img width="1544" alt="image" src="https://user-images.githubusercontent.com/59186927/195115446-086804b2-ceb7-4bfe-ab02-7779fcdf637e.png">

3. Bug: Species show page (with its table of list of genes), will show state mismatch error when refreshed.

- Not a very visible issue but solved by debugging react-table implementation that causes the state mismatch, now purely rely on API call to get data for the table of genes instead of mixing both Next.js's server-side props and also API calls.

- Also managed to decompose the virtually paginated table as an independent component for component reusability

5. Move pagination bar to the top.

Context: Marek's comment on the page moving away after clicking next page

6. Created the API's need to make the name functionality work on the search page results

