### PR TITLE
Enhance species genes list

### DIFF
--- a/components/tables/GenesTable.tsx
+++ b/components/tables/GenesTable.tsx
@@ -25,6 +25,7 @@ const GenesTable: React.FC<IProps> = ({ taxid }) => {
         </TextLink>
       ),
     },
+    /* No Alias stored in DB yet for now, so leaving it out first */
     // {
     //   Header: "Alias",
     //   accessor: "alias",
@@ -32,11 +33,17 @@ const GenesTable: React.FC<IProps> = ({ taxid }) => {
     {
       Header: "Mapman annotations",
       accessor: "gene_annotations",
-      Cell: ({ value: geneAnnotations }: { value: string }) => (
-        <ul className="space-y-1 max-w-md list-disc list-outside">
+      Cell: ({ value: geneAnnotations }: { value: object[] }) => (
+        <ul className="">
           {
+            /* If not gene annotation in the DB, just rended MAPMAN bin 35.2 */
+            (geneAnnotations.filter(ga => ga.type == "MAPMAN").length === 0) ? (
+              <li className="mb-2 last:mb-0">
+                not assigned.not annotated
+              </li>
+            ) :
             geneAnnotations.filter(ga => ga.type == "MAPMAN").map(ga => (
-              <li className="mb-1" key={ga.label}>
+              <li className="mb-2 last:mb-0" key={ga.label}>
                 {ga.name}
               </li>
             ))

--- a/components/tables/GenesTable.tsx
+++ b/components/tables/GenesTable.tsx
@@ -5,12 +5,14 @@ import TextLink from "../atomic/TextLink"
 
 interface IProps {
   taxid: number
+  initalGenes: object[]
+  pageTotal: number
 }
 
-const GenesTable: React.FC<IProps> = ({ taxid }) => {
+const GenesTable: React.FC<IProps> = ({ taxid, initialGenes, pageTotal }) => {
   // Pagination state management
-  const [ genesPage, setGenesPage ] = React.useState([])
-  const [ pageCount, setPageCount ] = React.useState(0)
+  const [ genesPage, setGenesPage ] = React.useState(initialGenes)
+  const [ pageCount, setPageCount ] = React.useState(pageTotal)
   const [ loading, setLoading ] = React.useState(false)
   const fetchIdRef = React.useRef(0)
 

--- a/components/tables/generics/VirtualPaginatedTable.tsx
+++ b/components/tables/generics/VirtualPaginatedTable.tsx
@@ -28,7 +28,7 @@ const VirtualPaginatedTable: React.FC<IProps> = ({
     page,  // Instead of rows
     canPreviousPage,
     canNextPage,
-    // pageOptions,
+    pageOptions,
     pageCount,
     gotoPage,
     nextPage,
@@ -141,6 +141,20 @@ const VirtualPaginatedTable: React.FC<IProps> = ({
             )}
           </tbody>
         </table>
+        {/* Optional foorter row */}
+        <div className="px-3">
+          {loading ? (
+            <span>Loading ...</span>
+          ) : (
+            <span>
+              Page{' '}
+              <strong>
+                {pageIndex + 1}
+              </strong>{' '}
+              of {pageOptions.length}
+            </span>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/pages/species/[taxid]/index.tsx
+++ b/pages/species/[taxid]/index.tsx
@@ -18,8 +18,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
   return {
     props: {
       species: JSON.parse(JSON.stringify(this_species)),
-      // initialGenes: JSON.parse(JSON.stringify(genePage.genes)),
-      // pageTotal: genePage.pageTotal,
+      initialGenes: JSON.parse(JSON.stringify(genePage.genes)),
+      pageTotal: genePage.pageTotal,
       numGenes: genePage.numGenes,
     },
   }
@@ -30,7 +30,7 @@ interface IProps {
   numGenes: number
 }
 
-const SpeciesPage: NextPage<IProps> = ({ species, numGenes }) => {
+const SpeciesPage: NextPage<IProps> = ({ species, numGenes, initialGenes, pageTotal }) => {
   const router = useRouter()
   const taxid = parseInt(router.query.taxid!)
 
@@ -50,7 +50,7 @@ const SpeciesPage: NextPage<IProps> = ({ species, numGenes }) => {
       </section>
 
       <section>
-        <GenesTable taxid={taxid} />
+        <GenesTable taxid={taxid} initialGenes={initialGenes} pageTotal={pageTotal} />
       </section>
     </Layout>
   )


### PR DESCRIPTION
## Context 

There were some style/slow issues after refactoring the table component out to its own independent reusable component

## What has been done

1. Add back the footer to reflect the current gene table page we are at. 

- path: `/species/[taxid]`

- Previously this component causes issues with the server and local state are not matching error, especially on page refresh.

<img width="941" alt="image" src="https://user-images.githubusercontent.com/59186927/195248345-a0df8305-c1ab-444f-baef-439996b64b20.png">

2. Some genes have no gene annotation in the db, we add bin 35.2 "not assigned.not annotated" to render to viewers on the front end side.

3. Server side props for initial page restored

- Initial issues with server side render vs client side render page UI state mismatch, so I made everything client side

- On production, I notice that this causes a lag for the table to be initially loaded, which is not too pleasant.

- Added back server-side props for initial page load to not have an empty table on first load.
