### PR TITLE
Cleanup/graph 1

### DIFF
--- a/components/atomic/inputs/Radio.tsx
+++ b/components/atomic/inputs/Radio.tsx
@@ -12,6 +12,10 @@ interface IProps {
   handleChange: (id: string) => void
 }
 
+/*
+  NOTE:
+  the groupName and the id for radioOptions have to be unique globally on the same page!
+*/
 const Radio: React.FC<IProps> = ({ groupName, radioOptions, selected: initialSelected, handleChange }) => {
   const [ selectedId, setSelectedId ] = React.useState(initialSelected)
 
@@ -19,7 +23,7 @@ const Radio: React.FC<IProps> = ({ groupName, radioOptions, selected: initialSel
     <div
       onChange={e => {
         setSelectedId(e.target.id)
-        handleChange(e.target.id.replace(groupName, ""))
+        handleChange(e.target.id)
       }}
     >
       {radioOptions.map((radioOption) => (
@@ -27,12 +31,12 @@ const Radio: React.FC<IProps> = ({ groupName, radioOptions, selected: initialSel
           <input
             type="radio"
             name={groupName}
-            id={groupName + radioOption.id}
+            id={radioOption.id}
             value={radioOption.id}  // Redundant
-            checked={groupName + radioOption.id === selectedId}
+            checked={radioOption.id === selectedId}
             className="w-4 h-4"
           />
-          <label htmlFor={groupName + radioOption.id} className="ml-2">
+          <label htmlFor={radioOption.id} className="ml-2">
             {radioOption.label}
           </label>
         </div>

--- a/components/atomic/tabs/TabBodyGroup.tsx
+++ b/components/atomic/tabs/TabBodyGroup.tsx
@@ -4,9 +4,9 @@ interface IProps {
   children: React.ReactNode
 }
 
-const TabBodyGroup: React.FC<IProps> = ({ children }) => {
+const TabBodyGroup: React.FC<IProps> = ({ children, ...otherProps }) => {
   return (
-    <ul className="mt-3">
+    <ul className="mt-3" {...otherProps}>
       {children}
     </ul>
   )

--- a/components/atomic/tabs/TabBodyItem.tsx
+++ b/components/atomic/tabs/TabBodyItem.tsx
@@ -7,13 +7,13 @@ interface IProps {
   children: React.ReactNode
 }
 
-const TabBodyItem: React.FC<IProps> = ({ tabIndex, children }) => {
+const TabBodyItem: React.FC<IProps & any> = ({ tabIndex, children, ...otherProps }) => {
   const { openTab } = React.useContext(TabContext)!
 
   return (
     <li
       hidden={openTab != tabIndex}
-      className=""
+      {...otherProps}
     >
       {children}
     </li>

--- a/components/atomic/tabs/TabGroup.tsx
+++ b/components/atomic/tabs/TabGroup.tsx
@@ -13,7 +13,7 @@ interface TabContextType {
 
 export const TabContext = React.createContext<TabContextType | null>(null)
 
-const TabGroup: React.FC<IProps> = ({ children, handleChangeTab }) => {
+const TabGroup: React.FC<IProps> = ({ children, handleChangeTab, ...otherProps }) => {
   const [ openTab, setOpenTab ] = React.useState(0)
 
   return (
@@ -21,6 +21,7 @@ const TabGroup: React.FC<IProps> = ({ children, handleChangeTab }) => {
       <div
         className="my-4"
         role="tablist"
+        {...otherProps}
       >
         {children}
       </div>

--- a/components/atomic/tabs/TabHeaderGroup.tsx
+++ b/components/atomic/tabs/TabHeaderGroup.tsx
@@ -4,11 +4,12 @@ interface IProps {
   children: React.ReactNode
 }
 
-const TabHeaderGroup: React.FC<IProps> = ({ children }) => {
+const TabHeaderGroup: React.FC<IProps> = ({ children, ...otherProps }) => {
   return (
     <ul
       className="flex flex-wrap text-center text-gray-500 border-b border-gray-400"
       role="tablist"
+      {...otherProps}
     >
       {children}
     </ul>

--- a/components/atomic/tabs/TabHeaderItem.tsx
+++ b/components/atomic/tabs/TabHeaderItem.tsx
@@ -7,7 +7,7 @@ interface IProps {
   children: React.ReactNode
 }
 
-const TabHeaderItem: React.FC<IProps> = ({ tabIndex, children }) => {
+const TabHeaderItem: React.FC<IProps> = ({ tabIndex, children, ...otherProps }) => {
   const { openTab, setOpenTab, handleChangeTab } = React.useContext(TabContext)!
 
   const selectedHeaderClass = "font-medium text-plb-green border-b-2 border-plb-green"
@@ -15,6 +15,7 @@ const TabHeaderItem: React.FC<IProps> = ({ tabIndex, children }) => {
   return (
     <li
       className="mr-2"
+      {...otherProps}
     >
       <a
         href="#"

--- a/components/graphs/ExpressionBarplot.tsx
+++ b/components/graphs/ExpressionBarplot.tsx
@@ -86,18 +86,18 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
         </p>
         <div className="mt-4 mb-8">
           <Radio
-            groupName="barplot-points-option"
+            groupName="barplot-options"
             radioOptions={[
-              { id: "full-range", label: "Full range" },
-              { id: "crop-out-outliers", label: "Scale without outliers" },
+              { id: "barplot-full", label: "Full range" },
+              { id: "barplot-scale-down", label: "Range without outliers" },
             ]}
-            selected="full-range"
+            selected="barplot-full"
             handleChange={(id) => {
               switch (id) {
-                case "full-range":
+                case "barplot-full":
                   setConstrainYRange(false)
                   break
-                case "crop-out-outliers":
+                case "barplot-scale-down":
                   setConstrainYRange(true)
                   break
                 default:

--- a/components/graphs/ExpressionBarplot.tsx
+++ b/components/graphs/ExpressionBarplot.tsx
@@ -20,6 +20,7 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
   return (
     <div className="my-4">
       <Plot
+        className="overflow-hidden border border-stone-300 rounded-2xl shadow-lg min-h-[600px]"
         data={[
           {
             type: 'bar',
@@ -73,8 +74,8 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
           modeBarButtonsToRemove: ["select2d", "lasso2d", "zoomIn2d", "zoomOut2d", "autoScale2d", "toImage"],
         }}
         style={{
-          position: "relative",
-          width: "100%",
+          // position: "relative",
+          // width: "100%",
         }}
         onInitialized={hideLoader}
         // useResizeHandler={true}

--- a/components/graphs/ExpressionBarplot.tsx
+++ b/components/graphs/ExpressionBarplot.tsx
@@ -24,18 +24,19 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
         data={[
           {
             type: 'bar',
-            x: organNames,  // Use organ names instead of PO terms
+            x: organNames,
             y: avgTpms,
             error_y: {
               type: "data",
               visible: true,
-              // color: "black",
-              thickness: 2,
+              color: "rgba(84, 84, 84, 0.6)",
+              thickness: 1.5,
               symmetric: true,
               array: stdDevs,
             },
-            marker: {color: 'green'},  // TODO: map color to groups of organs?
-            opacity: 0.4,
+            marker: {
+              color: "rgb(170, 227, 159)",
+            },
           },
         ]}
         layout={{
@@ -46,7 +47,6 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
             range: constrainYRange ? [ 0, highestTopWhisker + 1 ] : undefined,  // FROM STATE
           },
           height: 600,
-          // autosize: true,
           modebar: { orientation: "v" },
         }}
         config={{
@@ -88,8 +88,8 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
           <Radio
             groupName="barplot-options"
             radioOptions={[
-              { id: "barplot-full", label: "Full range" },
-              { id: "barplot-scale-down", label: "Range without outliers" },
+              { id: "barplot-full", label: "Full TPM-range" },
+              { id: "barplot-scale-down", label: "Scaled TPM-range" },
             ]}
             selected="barplot-full"
             handleChange={(id) => {

--- a/components/graphs/ExpressionBoxplot.tsx
+++ b/components/graphs/ExpressionBoxplot.tsx
@@ -31,22 +31,15 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
             hoverinfo: "y",  // default: "all", but we hide the name here, bcos too repetitive
             // hovertemplate: "",  // Refer to D3 formatting syntax if we need this in future
             // yhoverformat: "",
-            fillcolor: "green",
-            opacity: 0.5,
+            fillcolor: "rgb(170, 227, 159)",
             marker: {
-              color: "rgb(84, 84, 84)",
-              outliercolor: "rgba(172, 33, 33, 1)",
+              color: "rgba(84, 84, 84, 1)",
               opacity: 0.4,
               size: 4,
-              line: {
-              //   color: "rgb(220, 34, 164)",
-                outliercolor: "rgba(220, 34, 164, 1)",
-              }
+              line: { width: 0 }
             },
             line: {
-              // color: "green",
-              // color: "rgb(132, 168, 142)",
-              color: "rgb(144, 142, 142)",
+              color: "rgba(84, 84, 84, 0.6)",
             },
           }))
         }
@@ -57,7 +50,6 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
             range: constrainYRange ? [ 0, highestTopWhisker + 1 ] : undefined,  // FROM STATE
           },
           height: 600,
-          // autosize: true,
           modebar: { orientation: "v" },
         }}
         config={{
@@ -101,8 +93,8 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
             radioOptions={[
               { id: "boxplot-full", label: "All points (full range)" },
               { id: "boxplot-outlier-points", label: "Only outliers (full range)" },
-              { id: "boxplot-scale-down", label: "All points (range scaled)" },
-              { id: "boxplot-scale-down-no-points", label: "Hide points (range scaled)" },
+              { id: "boxplot-scale-down", label: "All points (scaled range)" },
+              { id: "boxplot-scale-down-no-points", label: "Only outliers (scaled range)" },
             ]}
             selected="boxplot-full"
             handleChange={(id) => {
@@ -112,7 +104,7 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
                   setConstrainYRange(false)
                   break
                   case "boxplot-outlier-points":
-                    setBoxpoints("suspectedoutliers")
+                    setBoxpoints("outliers")
                     setConstrainYRange(false)
                     break
                   case "boxplot-scale-down":

--- a/components/graphs/ExpressionBoxplot.tsx
+++ b/components/graphs/ExpressionBoxplot.tsx
@@ -97,25 +97,30 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
         </p>
         <div className="mt-4 mb-8">
           <Radio
-            groupName="boxplot-points-option"
+            groupName="boxplot-options"
             radioOptions={[
-              { id: "all-points", label: "All datapoints" },
-              { id: "only-outliers", label: "Only outliers" },
-              { id: "crop-out-outliers", label: "All datapoints (axis scaled)" },
+              { id: "boxplot-full", label: "All points (full range)" },
+              { id: "boxplot-outlier-points", label: "Only outliers (full range)" },
+              { id: "boxplot-scale-down", label: "All points (range scaled)" },
+              { id: "boxplot-scale-down-no-points", label: "Hide points (range scaled)" },
             ]}
-            selected="all-points"
+            selected="boxplot-full"
             handleChange={(id) => {
               switch (id) {
-                case "all-points":
+                case "boxplot-full":
                   setBoxpoints("all")
                   setConstrainYRange(false)
                   break
-                  case "only-outliers":
+                  case "boxplot-outlier-points":
                     setBoxpoints("suspectedoutliers")
                     setConstrainYRange(false)
                     break
-                  case "crop-out-outliers":
+                  case "boxplot-scale-down":
                     setBoxpoints("all")
+                    setConstrainYRange(true)
+                    break
+                  case "boxplot-scale-down-no-points":
+                    setBoxpoints("outliers")
                     setConstrainYRange(true)
                     break
                 default:

--- a/components/graphs/ExpressionBoxplot.tsx
+++ b/components/graphs/ExpressionBoxplot.tsx
@@ -22,7 +22,7 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
         data={
           sampleAnnotations.map(sa => ({
             type: "box",
-            quartilemethod: "inclusive",
+            quartilemethod: "exclusive",
             y: sa.tpms,
             boxpoints: boxpoints,  // FROM STATE
             jitter: 0.5,

--- a/components/graphs/ExpressionBoxplot.tsx
+++ b/components/graphs/ExpressionBoxplot.tsx
@@ -16,8 +16,9 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
   const highestTopWhisker = Math.max(...sampleAnnotations.map(sa => sa.topWhisker))
 
   return (
-    <div className="relative my-4">
+    <div className="my-4">
       <Plot
+        className="overflow-hidden border border-stone-300 rounded-2xl shadow-lg min-h-[600px]"
         data={
           sampleAnnotations.map(sa => ({
             type: "box",
@@ -84,8 +85,8 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
           modeBarButtonsToRemove: ["select2d", "lasso2d", "zoomIn2d", "zoomOut2d", "autoScale2d", "toImage"],
         }}
         style={{
-          position: "relative",
-          width: "100%",
+          // position: "relative",
+          // width: "100%",
         }}
         onInitialized={hideLoader}
         // useResizeHandler={true}

--- a/components/graphs/ExpressionBoxplot.tsx
+++ b/components/graphs/ExpressionBoxplot.tsx
@@ -22,6 +22,7 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
         data={
           sampleAnnotations.map(sa => ({
             type: "box",
+            quartilemethod: "inclusive",
             y: sa.tpms,
             boxpoints: boxpoints,  // FROM STATE
             jitter: 0.5,

--- a/components/graphs/ExpressionTabs.tsx
+++ b/components/graphs/ExpressionTabs.tsx
@@ -35,7 +35,6 @@ const ExpressionTabs: React.FC<IProps> = ({ sampleAnnotations }) => {
 
   const handleChangeTab = (tabIndex: number) => {
     const plotlyDivs = document.getElementsByClassName("js-plotly-plot")
-    console.log("Resizing: ")
     Plotly.Plots.resize(plotlyDivs[tabIndex])
   }
 

--- a/components/graphs/ExpressionTabs.tsx
+++ b/components/graphs/ExpressionTabs.tsx
@@ -2,8 +2,6 @@ import dynamic from "next/dynamic"
 import React from "react"
 import Plotly from "plotly.js"
 
-// const Plotly = dynamic(() => import("plotly.js"), {ssr: false})
-
 import {
   TabGroup,
   TabHeaderGroup,
@@ -37,12 +35,14 @@ const ExpressionTabs: React.FC<IProps> = ({ sampleAnnotations }) => {
 
   const handleChangeTab = (tabIndex: number) => {
     const plotlyDivs = document.getElementsByClassName("js-plotly-plot")
+    console.log("Resizing: ")
     Plotly.Plots.resize(plotlyDivs[tabIndex])
   }
-  // handleChangeTab.bind(document)
 
   return (
-    <TabGroup handleChangeTab={handleChangeTab}>
+    <TabGroup
+      handleChangeTab={handleChangeTab}
+    >
       <TabHeaderGroup>
         <TabHeaderItem key="barchart" tabIndex={0}>
           Barchart
@@ -53,17 +53,15 @@ const ExpressionTabs: React.FC<IProps> = ({ sampleAnnotations }) => {
       </TabHeaderGroup>
       <TabBodyGroup>
         <TabBodyItem key="barchart" tabIndex={0}>
-          {
-            /*
-              ExpressionBarplot will only be loaded on client side,
-              so the loading placeholder should be outside of that component
-            */
-            showLoader && (
-              <div id="graph-loading-placeholder">
-                <Loader comment="Drawing the graph" />
-              </div>
-            )
-          }
+          {/*
+            ExpressionBarplot will only be loaded on client side,
+            so the loading placeholder should be outside of that component
+          */}
+          {showLoader && (
+            <div id="graph-loading-placeholder">
+              <Loader comment="Drawing the graph" />
+            </div>
+          )}
           <ExpressionBarplot hideLoader={hideLoader} sampleAnnotations={sampleAnnotations} />
         </TabBodyItem>
         <TabBodyItem key="boxplot" tabIndex={1}>

--- a/pages/species/[taxid]/genes/[geneLabel].tsx
+++ b/pages/species/[taxid]/genes/[geneLabel].tsx
@@ -8,7 +8,6 @@ import Layout from "../../../../components/Layout"
 import TextLink from "../../../../components/atomic/TextLink"
 import MapmanTable from "../../../../components/tables/MapmanTable"
 import InterproTable from "../../../../components/tables/InterproTable"
-// import ExpressionTabs from "../../../../components/graphs/ExpressionTabs"
 
 const ExpressionTabs = dynamic(() => import("../../../../components/graphs/ExpressionTabs"), {ssr: false})
 

--- a/utils/stats.ts
+++ b/utils/stats.ts
@@ -20,14 +20,21 @@ export const getStdDev = (values: number[]): number => {
 }
 
 /*
-  Return [ topWhisker, bottomWhisker ]
+  Return [ bottomWhisker, topWhisker ]
 */
 export const getWhiskers = (values: number[]): [number, number] => {
   if (values.length == 0) { return [ 0, 0 ] }
   const [ q1, q2, q3 ] = quantileSeq(values, [ 0.25, 0.5, 0.75 ], false)
   const iqr = q3 - q1
-  const topWhisker = q3 + iqr
+  let topWhisker = q3 + 1.5 * iqr
+  // Top whisker as the highest point below q3 + iqr
+  const points = values.filter(tpm => tpm > q3 && tpm <= topWhisker)
+  if (points.length > 0) {
+    topWhisker = Math.max(...points)
+  } else {
+    topWhisker = q3
+  }
+  // Bottom whisker doesn't matter for now
   const bottomWhisker = Math.max(0, q1 - iqr)
-  // TODO: Can be more specific by giving the whisker as the highest point below q3 + iqr
   return [ bottomWhisker, topWhisker ]
 }

--- a/utils/stats.ts
+++ b/utils/stats.ts
@@ -1,4 +1,4 @@
-import { quantileSeq } from "mathjs"
+import { mean, quantileSeq } from "mathjs"
 
 export const roundDecimal = (value: number, decimalPoints: number = 3): number => {
   if (!decimalPoints || !Number.isInteger(decimalPoints)) {
@@ -19,12 +19,49 @@ export const getStdDev = (values: number[]): number => {
   return roundDecimal(rawStdDev, 3)
 }
 
+/* Because mathjs doesnt implement linear method ... */
+export const getLinearQuartiles = (values: number[]): [number, number, number] => {
+  values.sort((a, b) => a - b)
+  if (values.length === 0) return [0, 0, 0]
+  if (values.length === 1) return [values[0], values[0], values[0]]
+  if (values.length === 2) return [values[0], (values[0] + values[1]) / 2, values[1]]
+  if (values.length === 3) return [values[0], values[1], values[2]]
+
+  const n = values.length
+  const q2Index = Math.floor(n / 2)
+  /* q2Index also = number of elements on each side, whether n is even or odd */
+  const q1Index = Math.floor(q2Index / 2)
+  const q3Index = q1Index + q2Index
+  let q1, q2, q3
+  if (n % 2 === 0) {
+    q2 = (values[q2Index - 1] + values[q2Index]) / 2
+    if (q2Index % 2 === 0) { /* Guaranteed: n is even */
+      q1 = (values[q1Index - 1] + values[q1Index]) / 2
+      q3 = (values[q3Index - 1] + values[q3Index]) / 2
+    } else { /* q2Index % 2 === 0 */
+      q1 = values[q1Index]
+      q3 = values[q3Index]
+    }
+  } else { /* n % 2 === 1 */
+    q2 = values[q2Index]
+    if (q2Index % 2 === 0) {
+      q1 = (values[q1Index - 1] + values[q1Index]) / 2
+      q3 = (values[q3Index] + values[q3Index + 1]) / 2
+    } else { /* q2Index % 2 === 1 */
+      q1 = values[q1Index]
+      q3 = values[q3Index + 1]
+    }
+  }
+  return [ q1, q2, q3 ]
+}
+
 /*
   Return [ bottomWhisker, topWhisker ]
 */
 export const getWhiskers = (values: number[]): [number, number] => {
   if (values.length == 0) { return [ 0, 0 ] }
-  const [ q1, q2, q3 ] = quantileSeq(values, [ 0.25, 0.5, 0.75 ], false)
+  // const [ q1, q2, q3 ] = quantileSeq(values, [ 0.25, 0.5, 0.75 ], false)
+  const [ q1, q2, q3 ] = getLinearQuartiles(values)
   const iqr = q3 - q1
   let topWhisker = q3 + 1.5 * iqr
   // Top whisker as the highest point below q3 + iqr


### PR DESCRIPTION
## What has been done

### 1. Calculation of quartiles issue

Align the method of calculation of quartiles by the box plot and the method we use to rescale the y axis to hide extreme outliers if needed.

### 2. Radio button bug

The radio buttons have conflicting option id even though the group names are different. Fixed by namespacing option id.

### 3. Plot change to `position: absolute` bug when resizing window

Arbitarily set min height to the container div holding plotly plot so the bottom elements will remain in the correct position on the page even when plotly plot is reloading or dissapears momentarily.

### other cleanups

-