### PR TITLE
Fix/graph scale margin

### DIFF
--- a/components/graphs/ExpressionBarplot.tsx
+++ b/components/graphs/ExpressionBarplot.tsx
@@ -15,7 +15,7 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
   }
 
   const [ constrainYRange, setConstrainYRange ] = React.useState(false)
-  const highestTopWhisker = Math.max(...sampleAnnotations.map(sa => sa.topWhisker))
+  const highestAvgTpm = Math.max(...sampleAnnotations.map(sa => sa.avg_tpm))
 
   return (
     <div className="my-4">
@@ -44,7 +44,7 @@ const ExpressionBarplot = ({ sampleAnnotations, hideLoader }) => {
           yaxis: {
             title: "TPM",
             rangemode: "nonnegative",
-            range: constrainYRange ? [ 0, highestTopWhisker + 1 ] : undefined,  // FROM STATE
+            range: constrainYRange ? [ 0, highestAvgTpm * 1.01 ] : undefined,  // FROM STATE
           },
           height: 600,
           modebar: { orientation: "v" },

--- a/components/graphs/ExpressionBoxplot.tsx
+++ b/components/graphs/ExpressionBoxplot.tsx
@@ -48,10 +48,11 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
           xaxis: { automargin: true, tickangle: -90 },
           yaxis: {
             title: "TPM",
-            range: constrainYRange ? [ 0, highestTopWhisker + 1 ] : undefined,  // FROM STATE
+            range: constrainYRange ? [ 0, highestTopWhisker * 1.01] : undefined,  // FROM STATE
           },
           height: 600,
           modebar: { orientation: "v" },
+          dragmode: "pan",
         }}
         config={{
           responsive: true,
@@ -76,6 +77,7 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
             },
           ],
           modeBarButtonsToRemove: ["select2d", "lasso2d", "zoomIn2d", "zoomOut2d", "autoScale2d", "toImage"],
+          // scrollZoom: true,
         }}
         style={{
           // position: "relative",
@@ -104,18 +106,18 @@ const ExpressionBoxplot = ({ hideLoader, sampleAnnotations }) => {
                   setBoxpoints("all")
                   setConstrainYRange(false)
                   break
-                  case "boxplot-outlier-points":
-                    setBoxpoints("outliers")
-                    setConstrainYRange(false)
-                    break
-                  case "boxplot-scale-down":
-                    setBoxpoints("all")
-                    setConstrainYRange(true)
-                    break
-                  case "boxplot-scale-down-no-points":
-                    setBoxpoints("outliers")
-                    setConstrainYRange(true)
-                    break
+                case "boxplot-outlier-points":
+                  setBoxpoints("outliers")
+                  setConstrainYRange(false)
+                  break
+                case "boxplot-scale-down":
+                  setBoxpoints("all")
+                  setConstrainYRange(true)
+                  break
+                case "boxplot-scale-down-no-points":
+                  setBoxpoints("outliers")
+                  setConstrainYRange(true)
+                  break
                 default:
                   break
               }


### PR DESCRIPTION
## What has been done

### 1. Boxplot: Margin above highest whisker in % instead of absolute

When TPM range from 1 - 5 only, `highestWhisker + 1` makes the scale zoomed out instead of zooming in.

Eg: Gene TRAESCS5B02G140100

<img width="899" alt="image" src="https://user-images.githubusercontent.com/59186927/196697406-01082f21-807b-4754-8a20-9afd96fdf10b.png">

The fix: `highestWhisker * 1.01`

Eg after fix:

On smaller TPMs
![image](https://user-images.githubusercontent.com/59186927/196697774-98c57820-4202-4a42-8cbb-746a88ff865e.png)

And on larger TPMs
![image](https://user-images.githubusercontent.com/59186927/196697883-83c5b126-ae00-42db-bcde-0f8075cca63f.png)


### 2. Barplot range

Use maximum avg TPM instead of highestWhisker to scale/zoom in

Before: 
<img width="895" alt="image" src="https://user-images.githubusercontent.com/59186927/196698075-11fed49d-962d-46c5-946b-d1bb6fc782f5.png">

will scale to:
<img width="917" alt="image" src="https://user-images.githubusercontent.com/59186927/196698155-f17ba95f-335d-4bf1-b6a5-560394d79cbe.png">

After the fix:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/59186927/196698240-7eaaea08-ce59-4433-b62b-41a53773a8a0.png">


### 3. Default selected option on modebar of the graph

Set to pan