### PR TITLE
Feat: show more for long list of genes

### DIFF
--- a/components/atomic/TextLink.tsx
+++ b/components/atomic/TextLink.tsx
@@ -3,19 +3,21 @@ import Link from "next/link"
 
 interface IProps {
   href: string
-  moreClassName?: string
+  className?: string
+  moreClassName?: string  // To be deprecated
   children: React.ReactNode
 }
 
 const TextLink: React.FC<IProps & {[key: string]: any}> = ({
   href,
-  moreClassName = "",
+  className,
+  moreClassName,
   children,
   ...moreAttributes  /* Eg: target="_blank" in the element */
 }) => {
   return (
     <Link href={href}>
-      <a className={`text-plb-green hover:underline active:text-plb-red visited:text-plb-green ${moreClassName}`} {...moreAttributes}>
+      <a className={`text-plb-green hover:underline active:text-plb-red ${moreClassName} ${className}`} {...moreAttributes}>
       {/* <a className={`text-plb-green hover:underline active:text-plb-red visited:text-plb-red ${moreClassName}`} {...moreAttributes}> */}
         {children}
       </a>

--- a/components/atomic/texts/ShowMoreList.tsx
+++ b/components/atomic/texts/ShowMoreList.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+
+import TextLink from "../TextLink"
+
+interface IProps {
+  items: any[]
+}
+
+const ShowMoreList: React.FC<IProps> = ({ items }) => {
+  const [ showMore, setShowMore ] = React.useState(false)
+
+  const initialItems = items.slice(0, 10)
+  const moreItems = items.slice(10, -1)
+
+  const handleShowMore = (e) => {
+    e.preventDefault()
+    setShowMore(true)
+  }
+
+  const handleShowLess = (e) => {
+    e.preventDefault()
+    setShowMore(false)
+  }
+
+  return (
+    <div>
+      {/* Initial items */}
+      {initialItems.map((item, i) => (
+        <span key={i}>
+          {item}
+          <span hidden={(i === initialItems.length - 1) && (moreItems.length === 0)}>
+            {", "}
+          </span>
+        </span>
+      ))}
+      {/* More items */}
+      {showMore && moreItems.map((item, i) => (
+        <span key={i}>
+          {item}
+          <span hidden={(i === initialItems.length - 1)}>
+            {", "}
+          </span>
+        </span>
+      ))}
+
+      {/* Show more/less toggle */}
+      {moreItems.length > 0 && (showMore ? (
+        <TextLink
+          href="#"
+          moreClassName="text-stone-400 italic"
+          onClick={handleShowLess}
+        >
+          Show less
+        </TextLink>
+      ) : (
+        <TextLink
+          href="#"
+          className="text-stone-400 italic"
+          onClick={handleShowMore}
+        >
+          Show more ...
+        </TextLink>
+      ))}
+    </div>
+  )
+}
+
+export default ShowMoreList

--- a/components/tables/InterproShowTable.tsx
+++ b/components/tables/InterproShowTable.tsx
@@ -2,6 +2,7 @@ import React from "react"
 
 import LocalPaginatedTable from "./generics/LocalPaginatedTable"
 import TextLink from "../atomic/TextLink"
+import ShowMoreList from "../atomic/texts/ShowMoreList"
 
 const InterproShowTable = ({ data }) => {
   const columns = React.useMemo(
@@ -23,14 +24,13 @@ const InterproShowTable = ({ data }) => {
         Header: "Genes",
         accessor: "genes",
         Cell: ({ value, row }) => (
-          value.map((gene, i) => (
-            <span className="" key={i}>
-              <TextLink href={`/species/${row.values.tax}/genes/${gene.label}`}>
+          <ShowMoreList
+            items={value.map((gene, i) => (
+              <TextLink href={`/species/${row.values.tax}/genes/${gene.label}`} key={i}>
                 {gene.label}
               </TextLink>
-              {",  "}
-            </span>
-          ))
+            ))}
+          />
         ),
       },
     ], []


### PR DESCRIPTION
## Problem

Some Gene annotations have long list of genes attached to them. Very verbose.

## What has been done

Created a Show more/ show less component that takes a list and have a show more/less toggle

When applied to the PFAM show table:

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/59186927/196849854-f9fa4b3e-5861-41b9-b10d-9dd74b06183a.png">

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/59186927/196849864-28e5afc3-3dbc-4c18-b10b-f289cb1ee887.png">

And when the list is < 10, no difference from original

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/59186927/196849908-55252219-f8cf-44de-afa9-610acb113529.png">

