### PR TITLE
Feat: Sorting on PFAM index is global

### DIFF
--- a/components/tables/InterproIndexTable.tsx
+++ b/components/tables/InterproIndexTable.tsx
@@ -42,17 +42,21 @@ const InterproIndexTable: React.FC<IProps> = ({ initialGeneAnnotations, pageTota
               : goTerms.join(", ")
           }
         </ul>
-      )
+      ),
+      disableSortBy: true,
     },
   ], [])
 
-  const fetchGaPage = React.useCallback(({ pageSize, pageIndex, queryFilter=null }: IPropsFetchData) => {
+  const fetchGaPage = React.useCallback(({ pageSize, pageIndex, queryFilter=null, sortByObject={} }: IPropsFetchData) => {
     const fetchId = ++fetchIdRef.current
     setLoading(true)
     if (fetchId === fetchIdRef.current) {
       let apiUrl = `/api/interpro?pageIndex=${pageIndex}&pageSize=${pageSize}`
       if (queryFilter) {
         apiUrl += `&queryFilter=${queryFilter}`
+      }
+      if (Object.keys(sortByObject).length > 0) {
+        apiUrl += `&sortByObject=${JSON.stringify(sortByObject)}`
       }
       fetch(apiUrl)
       .then(res => res.json())

--- a/components/tables/generics/VirtualPaginatedFilterTable.tsx
+++ b/components/tables/generics/VirtualPaginatedFilterTable.tsx
@@ -107,7 +107,7 @@ const VirtualPaginatedTable: React.FC<IProps> = ({
         setGlobalFilter={setGlobalFilter}
         placeholder="Search by your PFAM ID or name ..."
       />
-      <div className="overflow-x-auto border border-stone-300 rounded-xl shadow-lg my-3">
+      <div className="overflow-x-auto border border-stone-300 rounded-3xl shadow-lg my-3 pt-1">
         <table className="w-full" {...getTableProps()}>
           <thead className="border-b">
             {headerGroups.map(headerGroup => (
@@ -160,7 +160,7 @@ const VirtualPaginatedTable: React.FC<IProps> = ({
           </tbody>
         </table>
         {/* Optional foorter row */}
-        <div className="px-3">
+        <div className="px-6 py-2">
           {loading ? (
             <span>Loading ...</span>
           ) : (

--- a/pages/api/interpro/index.ts
+++ b/pages/api/interpro/index.ts
@@ -9,14 +9,16 @@ export default async function handler(
   switch (req.method) {
     case "GET":
       try {
-        let { pageIndex: pageIndexIn, pageSize: pageSizeIn, queryFilter } = req.query
+        let { pageIndex: pageIndexIn, pageSize: pageSizeIn, queryFilter, sortByObject: sortByStr } = req.query
         const pageIndex = parseInt(pageIndexIn as string) || 0
         const pageSize = parseInt(pageSizeIn as string) || parseInt(process.env.pageSize!)
+        const sortByObject = sortByStr ? JSON.parse(sortByStr as string) : {}
         const genePage = await getGeneAnnotationsPage({
           type: "INTERPRO",
           pageIndex,
           pageSize,
           queryFilter,
+          sortByObject,
         })
         if (pageIndex < 0 || pageIndex > genePage.pageTotal) {
           res.status(422).json({

--- a/utils/geneAnnotations.ts
+++ b/utils/geneAnnotations.ts
@@ -6,6 +6,7 @@ interface InputArgs {
   pageIndex: number
   pageSize: number
   queryFilter?: string | null
+  sortByObject?: object
 }
 
 export const getGeneAnnotationsPage = async ({
@@ -13,6 +14,7 @@ export const getGeneAnnotationsPage = async ({
   pageIndex = 0,
   pageSize = parseInt(process.env.pageSize!),
   queryFilter = null,
+  sortByObject,
 }: InputArgs) => {
   connectMongo()
   const queryObject = { type: type }
@@ -23,6 +25,7 @@ export const getGeneAnnotationsPage = async ({
     ]
   }
   const geneAnnotations = await GeneAnnotation.find(queryObject)
+    .sort(sortByObject)
     .skip(pageIndex * pageSize)
     .limit(pageSize)
   const numGeneAnnotations = await GeneAnnotation.countDocuments(queryObject)


### PR DESCRIPTION
## What has been done

Sorting on PFAM index is global via calling the API -> Mongoose internal sort to return results paginated, filtered by sort method.

Note that sorting is only by PFAM ID and name, not GO Terms. 