### PR TITLE
feat: update pcc query to match db changes

### DIFF
--- a/components/tables/PccTable.tsx
+++ b/components/tables/PccTable.tsx
@@ -8,7 +8,7 @@ const PccTable = ({ taxid, data }) => {
     () => [
       {
         Header: "Gene",
-        accessor: "label",
+        accessor: "gene.label",
         Cell: ({ value }) => (
           <TextLink href={`/species/${taxid}/genes/${value}`}>
             {value}
@@ -17,10 +17,10 @@ const PccTable = ({ taxid, data }) => {
       },
       {
         Header: "Description",
-        accessor: "names",
+        accessor: "gene.gene_annotations",
         Cell: ({ value }) => (
-          value.map(n => (
-            <p className="mt-1.5 first:mt-0" key={n}>{n}</p>
+          value && value.map(ga => (
+            <p className="mt-1.5 first:mt-0" key={ga._id}>{ga.name}</p>
           ))
         ),
       },

--- a/models/gene.js
+++ b/models/gene.js
@@ -3,9 +3,12 @@ import { Schema, model, models, ObjectId } from "mongoose";
 import GeneAnnotation from "./geneAnnotation";
 
 const neighborSchema = new Schema({
-  label: String,
+  gene: {
+    type: ObjectId,
+    ref: "Gene",
+  },
   pcc: Number,
-})
+});
 
 const geneSchema = new Schema({
   label: {
@@ -36,12 +39,6 @@ geneSchema.virtual("gene_annotations", {
   ref: "GeneAnnotation",
   localField: "ga_ids",
   foreignField: "_id",
-})
-
-geneSchema.virtual("neighborGenes", {
-  ref: "Gene",
-  localField: "neighbors.label",
-  foreignField: "label",
 })
 
 /* These are needed for virtual fields to appear */

--- a/utils/genes.ts
+++ b/utils/genes.ts
@@ -65,23 +65,10 @@ export const getOneGene = async (
   const gene = await Gene.findOne({"spe_id": species_id, "label": label})
     .populate("gene_annotations")
     .populate({
-      path: "neighborGenes",
-      select: "ga_ids",
-      populate: {
-        path: "gene_annotations",
-      }
-    }).lean()
-  const geneNameMap = gene.neighborGenes.reduce((coll, curr) => {
-    const mapmanNames = curr.gene_annotations
-      .filter(ga => ga.type === "MAPMAN")
-      .map(ga => ga.name)
-      coll[curr.label] = mapmanNames
-      return coll
-  }, {})
-  gene.neighbors.forEach((neighbor, i) => {
-    neighbor.names = geneNameMap[neighbor.label]
-  })
-  delete gene.neighborGenes
+      path: "neighbors.gene",
+      select: "label ga_ids",
+      populate: "gene_annotations",
+    })
   return gene
 }
 


### PR DESCRIPTION
neighbours store gene via gene id instead of gene label, which is not globally unique.