### PR TITLE
fix: make navbar sticky

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -17,8 +17,8 @@ export default function Layout({ children }) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <header className="">
-        <nav className="sticky bg-plb-green py-4 pl-4 pr-2 md:px-2">
+      <header className="sticky top-0 z-20">
+        <nav className="bg-plb-green py-4 pl-4 pr-2 md:px-6">
           <div className="container flex flex-wrap justify-between items-center mx-auto">
             <TextLink href="/" className="self-center whitespace-nowrap text-gray-50 text-xl font-medium">
               Omnibus

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -18,6 +18,11 @@ export default function Layout({ children }) {
       </Head>
 
       <header className="sticky top-0 z-20">
+        {/*
+          TOFIX:
+          mobile hamburger doesnt work on routing to other pages
+          flowbite issue with chrome browsers, not urgent for now, to be fixed next time
+        */}
         <nav className="bg-plb-green py-4 pl-4 pr-2 md:px-6">
           <div className="container flex flex-wrap justify-between items-center mx-auto">
             <TextLink href="/" className="self-center whitespace-nowrap text-gray-50 text-xl font-medium">


### PR DESCRIPTION
## What has been done

Make navbar sticky - sticky tailwind class was placed at the wrong div.

## Not fixed

Hamburger doesnt work when routing to other pages. Reported as chrome specific issue with flowbite. 