### PR TITLE
Fix: PCC table search

### DIFF
--- a/components/tables/PccTable.tsx
+++ b/components/tables/PccTable.tsx
@@ -14,18 +14,21 @@ const PccTable = ({ taxid, data }) => {
             {value}
           </TextLink>
         ),
+        disableSortBy: true,
       },
       {
         Header: "Description",
-        accessor: "gene.mapman_annotations",
-        Cell: ({ value }) => {
-          if (value && value.length > 0) {
-            return value.map(ga => (
+        accessor: row => row.gene.mapman_annotations.map(anot => anot.name),
+        Cell: ({ row }) => {
+          const anots = row.original.gene.mapman_annotations
+          if (anots && anots.length > 0) {
+            return anots.map(ga => (
               <p className="mt-1.5 first:mt-0" key={ga._id}>{ga.name}</p>
             ))
           }
           return (<p>not assigned.not annotated</p>)
-        }
+        },
+        disableSortBy: true,
       },
       {
         Header: "PCC Value",

--- a/components/tables/generics/PaginationBar.tsx
+++ b/components/tables/generics/PaginationBar.tsx
@@ -12,70 +12,68 @@ const PaginationBar: React.FC = ({
   setPageSize,
 }) => {
   return (
-    // <nav className="flex justify-center my-3">
-      <div className="flex text-center drop-shadow">
-        <button
-          className="py-3 px-5 pl-6 text-gray-500 bg-white rounded-l-full border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
-          onClick={() => gotoPage(0)}
-          disabled={!canPreviousPage}
-        >
-          First
-        </button>
-        <button
-          className="py-3 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
-          onClick={() => previousPage()}
-          disabled={!canPreviousPage}
-        >
-          {'<'}
-        </button>
-        <div
-          className="grow py-3 px-5 text-gray-500 bg-white border border-gray-300"
-        >
-          Go to{" "}
-          <input
-            className="text-center border border-stone-300"
-            type="number"
-            defaultValue={pageIndex + 1}
-            onChange={e => {
-              const page = e.target.value ? Number(e.target.value) - 1 : 0
-              gotoPage(page)
-            }}
-            style={{ width: '50px' }}
-          />
-        </div>
-        <div
-          className="grow py-3 px-5 text-gray-500 bg-white border border-gray-300"
-        >
-          <select
-            className="border border-stone-300"
-            value={pageSize}
-            onChange={e => {
-              setPageSize(Number(e.target.value))
-            }}
-          >
-            {[10, 20, 30, 40, 50].map(pageSize => (
-              <option key={pageSize} value={pageSize}>
-                Show {pageSize}
-              </option>
-            ))}
-          </select>
-        </div>
-        <button
-          className="py-3 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
-          onClick={() => nextPage()}
-          disabled={!canNextPage}
-        >
-          {'>'}
-        </button>
-        <button
-          className="py-3 px-5 pr-6 text-gray-500 bg-white rounded-r-full border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
-          onClick={() => gotoPage(pageCount - 1)}
-          disabled={!canNextPage}
-        >
-          Last
-        </button>
+    <div className="flex text-center drop-shadow">
+      <button
+        className="py-3 px-5 pl-6 text-gray-500 bg-white rounded-l-full border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        onClick={() => gotoPage(0)}
+        disabled={!canPreviousPage}
+      >
+        First
+      </button>
+      <button
+        className="py-3 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        onClick={() => previousPage()}
+        disabled={!canPreviousPage}
+      >
+        {'<'}
+      </button>
+      <div
+        className="grow py-1.5 px-5 text-gray-500 bg-white border border-gray-300"
+      >
+        Go to{" "}
+        <input
+          className="p-1 text-center border border-stone-200"
+          type="number"
+          defaultValue={pageIndex + 1}
+          onChange={e => {
+            const page = e.target.value ? Number(e.target.value) - 1 : 0
+            gotoPage(page)
+          }}
+          style={{ width: '80px' }}
+        />
       </div>
-    // </nav>
+      <div
+        className="grow py-1.5 px-5 text-gray-500 bg-white border border-gray-300"
+      >
+        <select
+          className="p-1 pr-6 border border-stone-200"
+          value={pageSize}
+          onChange={e => {
+            setPageSize(Number(e.target.value))
+          }}
+        >
+          {[10, 20, 30, 40, 50].map(pageSize => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        className="py-3 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        onClick={() => nextPage()}
+        disabled={!canNextPage}
+      >
+        {'>'}
+      </button>
+      <button
+        className="py-3 px-5 pr-6 text-gray-500 bg-white rounded-r-full border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        onClick={() => gotoPage(pageCount - 1)}
+        disabled={!canNextPage}
+      >
+        Last
+      </button>
+    </div>
   )
 }
 

--- a/components/tables/generics/PaginationBar.tsx
+++ b/components/tables/generics/PaginationBar.tsx
@@ -14,14 +14,14 @@ const PaginationBar: React.FC = ({
   return (
     <div className="flex text-center drop-shadow">
       <button
-        className="py-3 px-5 pl-6 text-gray-500 bg-white rounded-l-full border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        className="py-3 px-5 pl-6 text-gray-500 disabled:text-gray-300 bg-white rounded-l-full border border-gray-300 enabled:hover:bg-gray-100 enabled:hover:text-gray-700"
         onClick={() => gotoPage(0)}
         disabled={!canPreviousPage}
       >
         First
       </button>
       <button
-        className="py-3 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        className="py-3 px-5 text-gray-500 disabled:text-gray-300 bg-white border border-gray-300 enabled:hover:bg-gray-100 enabled:hover:text-gray-700"
         onClick={() => previousPage()}
         disabled={!canPreviousPage}
       >
@@ -60,14 +60,14 @@ const PaginationBar: React.FC = ({
         </select>
       </div>
       <button
-        className="py-3 px-5 text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        className="py-3 px-5 text-gray-500 disabled:text-gray-300 bg-white border border-gray-300 enabled:hover:bg-gray-100 enabled:hover:text-gray-700"
         onClick={() => nextPage()}
         disabled={!canNextPage}
       >
         {'>'}
       </button>
       <button
-        className="py-3 px-5 pr-6 text-gray-500 bg-white rounded-r-full border border-gray-300 hover:bg-gray-100 hover:text-gray-700"
+        className="py-3 px-5 pr-6 text-gray-500 disabled:text-gray-300 bg-white rounded-r-full border border-gray-300 enabled:hover:bg-gray-100 enabled:hover:text-gray-700"
         onClick={() => gotoPage(pageCount - 1)}
         disabled={!canNextPage}
       >


### PR DESCRIPTION
## What has been done

1. PCC Local table can search by mapman annotations too now. 

  - This is achieved by modifying the accessor to a callback, bcos react table filter cannot parse js objects directly for the search. Refer to `accessor` attribute of the columns object.

2. Pagination bar UI enhancement

  - Height of input field made smaller to make it not too fat
  - Buttons styled lighter when state is disabled (using css selector in tailwind)