### PR TITLE
Migrate GA Buckets - tax field to spe_id

### DIFF
--- a/components/tables/InterproShowTable.tsx
+++ b/components/tables/InterproShowTable.tsx
@@ -11,22 +11,18 @@ const InterproShowTable = ({ data }) => {
         Header: "Species",
         accessor: "species.name",
         Cell: ({ value, row }) => (
-          <TextLink href={`/species/${row.values.tax}`}>
+          <TextLink href={`/species/${row.original.species.tax}`}>
             {value}
           </TextLink>
         ),
       },
-      {
-        Header: "Tax ID",
-        accessor: "tax",
-      }, // To hide, but needed to access the value for species url
       {
         Header: "Genes",
         accessor: "genes",
         Cell: ({ value, row }) => (
           <ShowMoreList
             items={value.map((gene, i) => (
-              <TextLink href={`/species/${row.values.tax}/genes/${gene.label}`} key={i}>
+              <TextLink href={`/species/${row.original.species.tax}/genes/${gene.label}`} key={i}>
                 {gene.label}
               </TextLink>
             ))}
@@ -40,7 +36,7 @@ const InterproShowTable = ({ data }) => {
     <LocalPaginatedTable
       columns={columns}
       data={data}
-      hiddenColumns={["tax"]}
+      hiddenColumns={[]}
     />
   )
 }

--- a/components/tables/MapmanShowTable.tsx
+++ b/components/tables/MapmanShowTable.tsx
@@ -11,22 +11,18 @@ const MapmanShowTable = ({ data }) => {
         Header: "Species",
         accessor: "species.name",
         Cell: ({ value, row }) => (
-          <TextLink href={`/species/${row.values.tax}`}>
+          <TextLink href={`/species/${row.original.species.tax}`}>
             {value}
           </TextLink>
         ),
       },
-      {
-        Header: "Tax ID",
-        accessor: "tax",
-      }, // To hide, but needed to access the value for species url
       {
         Header: "Genes",
         accessor: "genes",
         Cell: ({ value, row }) => (
           <ShowMoreList
             items={value.map((gene, i) => (
-              <TextLink href={`/species/${row.values.tax}/genes/${gene.label}`} key={i}>
+              <TextLink href={`/species/${row.original.species.tax}/genes/${gene.label}`} key={i}>
                 {gene.label}
               </TextLink>
             ))}
@@ -40,7 +36,7 @@ const MapmanShowTable = ({ data }) => {
     <LocalPaginatedTable
       columns={columns}
       data={data}
-      hiddenColumns={["tax"]}
+      hiddenColumns={[]}
     />
   )
 }

--- a/models/geneAnnotationBucket.js
+++ b/models/geneAnnotationBucket.js
@@ -9,9 +9,10 @@ const geneAnnotationBucketSchema = new Schema(
       $type: ObjectId,
       required: true,
     },
-    tax: {
-      $type: Number,
+    spe_id: {
+      $type: ObjectId,
       required: true,
+      ref: "Species",
     },
     gene_ids: {
       $type: [ObjectId],
@@ -29,8 +30,8 @@ const geneAnnotationBucketSchema = new Schema(
 
 geneAnnotationBucketSchema.virtual("species", {
   ref: "Species",
-  localField: "tax",
-  foreignField: "tax",
+  localField: "spe_id",
+  foreignField: "_id",
   justOne: true,
 })
 geneAnnotationBucketSchema.virtual("genes", {

--- a/utils/geneAnnotations.ts
+++ b/utils/geneAnnotations.ts
@@ -48,12 +48,12 @@ export const getOneGeneAnnotation = async ({ type, label }) => {
   const geneAnnotation = await GeneAnnotation.findOne({ type: type, label: label})
     .populate({
       path: "gene_annotation_buckets",
-      select: "ga_id tax gene_ids",
+      select: "ga_id spe_id gene_ids",
       populate: [
         {
           path: "species",
           model: "Species",
-          select: "name taxid"
+          select: "name tax"
         },
         {
           path: "genes",


### PR DESCRIPTION
## What has been done

As the database has been migrated in the `gene_annotation_buckets` collection, one field has been changed:

- from `tax` to `spe_id`

This is to reflect the versioning flexibility and avoid confusion for the buckets. This PR accommodate this change on the frontend.